### PR TITLE
Fix for missing return statement from wnsPayload function.

### DIFF
--- a/src/UrbanAirship/Push/Notification.php
+++ b/src/UrbanAirship/Push/Notification.php
@@ -167,6 +167,7 @@ function wnsPayload($alert=null, $toast=null, $tile=null, $badge=null)
     if (count($payload) == 0) {
         throw new InvalidArgumentException("wnsPayload cannot be empty");
     }
+    return $payload;
 }
 
 /**


### PR DESCRIPTION
The wnsPayload function formerly did not return anything which was causing HTTP 400 errors during my requests to the API.

This fixes that issue.
