### PR TITLE
Changed the apid(Android) and device_token(iOS) to meet the new api v…

### DIFF
--- a/src/UrbanAirship/Push/Audience.php
+++ b/src/UrbanAirship/Push/Audience.php
@@ -33,7 +33,7 @@ function deviceToken($token)
         throw new InvalidArgumentException("Invalid iOS device token");
     }
 
-    return array("device_token" => $token);
+    return array("ios_channel" => $token);
 }
 
 /**
@@ -65,7 +65,7 @@ function apid($uuid)
         throw new InvalidArgumentException("Invalid APID");
     }
 
-    return array("apid" => $uuid);
+    return array("android_channel" => $uuid);
 }
 
 /**


### PR DESCRIPTION
We found the API Version update documentation stated that the "device_token" would be replaced by "ios_channel" and the "apid" would be replaced by "android_channel".
Refer Url:     http://docs.urbanairship.com/api/ua.html#push-object