### PR TITLE
adds named user support

### DIFF
--- a/src/UrbanAirship/Push/Audience.php
+++ b/src/UrbanAirship/Push/Audience.php
@@ -119,6 +119,16 @@ function alias($alias)
 }
 
 /**
+ * Select a single named user
+ * @param string $namedUser
+ * @return array
+ */
+function namedUser($namedUser)
+{
+	return array('named_user' => $namedUser);
+}
+
+/**
     * Select a single segment.
     * @param string $segment
 */


### PR DESCRIPTION
adds ability to push notifications by named users. 

usage:
```php
<?php
// ...
$airship->push()
    ->setAudience(P\namedUser('user-1234'))
    ->setNotification(P\notification('hello world'))
    ->setDeviceTypes(array('ios', 'android'))
    ->send();
// ...
?>
```
Note: device type cannot be set to P\all currently due to lack of named user support for windows. it must be an `array` containing one of or both `'ios'` and `'android'`